### PR TITLE
ingress implemented locally

### DIFF
--- a/frontend-cm.yaml
+++ b/frontend-cm.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: frontend-cm
+data:
+  appConfig.js: |
+    var appConfig = {
+      API_URL: `http://192.168.49.2/api/msgs`
+    };

--- a/frontend-deployment.yaml
+++ b/frontend-deployment.yaml
@@ -14,14 +14,20 @@ spec:
     spec:
       containers:
         - name: frontend-pod
-          image: virginity/minitwit_frontend:latest
+          image: virginity/minitwit_frontend:k8s1.0
           imagePullPolicy: Always
           ports:
             - containerPort: 3000
           command: ["/bin/sh"]
-          args: ["-c","serve -s build -l 3000"]
-          env:
-            - name: REACT_APP_API_URL
-              value: https://minitwit.online/api
+          args: ["-c","serve -s build -l 3000 -S"]
+          volumeMounts:
+            - mountPath: /app/build/config
+              name: frontend-config
+      volumes:
+        - configMap:
+            defaultMode: 420
+            name: frontend-cm
+            optional: true
+          name: frontend-config
 
       restartPolicy: Always

--- a/frontend-service.yaml
+++ b/frontend-service.yaml
@@ -4,7 +4,7 @@ metadata:
   name: frontend-service
 spec:
   selector:
-    app: react-backend
+    app: react-frontend
   ports:
     - name: frontend-port
       protocol: TCP

--- a/minitwit-ig.yaml
+++ b/minitwit-ig.yaml
@@ -3,8 +3,9 @@ kind: Ingress
 metadata:
   name: simulation-ig
   annotations: 
-    nginx.ingress.kubernetes.io/rewrite-target: /minitwitsimulation/$2
+    nginx.ingress.kubernetes.io/rewrite-target: /minitwitsimulation/$1
 spec:
+  ingressClassName: nginx
   rules:
   - http:
       paths:
@@ -25,6 +26,7 @@ metadata:
   annotations: 
     nginx.ingress.kubernetes.io/rewrite-target: /minitwit/$2
 spec:
+  ingressClassName: nginx
   rules:
   - http:
       paths:
@@ -43,6 +45,7 @@ kind: Ingress
 metadata:
   name: frontend-ig
 spec:
+  ingressClassName: nginx
   rules:
   - http:
       paths:

--- a/minitwit-ig.yaml
+++ b/minitwit-ig.yaml
@@ -24,7 +24,7 @@ kind: Ingress
 metadata:
   name: backend-ig
   annotations: 
-    nginx.ingress.kubernetes.io/rewrite-target: /minitwit/$2
+    nginx.ingress.kubernetes.io/rewrite-target: /minitwit/$1
 spec:
   ingressClassName: nginx
   rules:


### PR DESCRIPTION
## Describe your changes
Implemented Ingress `minitwit-ig` for our application on a local Minikube Cluster. 
- **Host is not specified in manifest but should specify our domain in production**
- **Seed environment variable is injected into backend in backend-deployment manifest (should be removed after main database is instatiated)**
- **Certificates have not been implemented**
- **Frontend configMap specifies a local IP but should specify our domain in production**

## Issue ticket number and link
#6

## Checklist for tasks done
- [x] I have performed a self-review of my code
- [x] Ready for merge
